### PR TITLE
Initialize monorepo for gui and agent

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  "env": {
+    "node": true,
+    "browser": true,
+    "es2020": true
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# AIChainHelper
+
+[![Build](https://img.shields.io/github/actions/workflow/status/your/repo/ci.yml?branch=main)](https://github.com/your/repo/actions)
+[![License](https://img.shields.io/github/license/your/repo)](LICENSE)
+
+Monorepo containing an Electron GUI and a CLI agent.
+
+## Packages
+
+- **apps/gui** - Electron app built with React, Vite and TypeScript
+- **packages/agent** - TypeScript agent library and CLI
+
+## Scripts
+
+- `pnpm dev` - start GUI and agent in development mode
+- `pnpm build` - type-check and build the GUI for macOS, Windows and Linux
+- `pnpm build:cli` - build the agent CLI only

--- a/apps/gui/package.json
+++ b/apps/gui/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "gui",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/main.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build && electron-builder -mwl"
+  },
+  "dependencies": {
+    "electron": "^29.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "typescript": "^5.0.0",
+    "electron-builder": "^24.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
+  }
+}

--- a/apps/gui/src/index.ts
+++ b/apps/gui/src/index.ts
@@ -1,0 +1,1 @@
+console.log('GUI');

--- a/apps/gui/tsconfig.json
+++ b/apps/gui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "aichainhelper",
+  "private": true,
+  "workspaces": [
+    "apps/gui",
+    "packages/agent"
+  ],
+  "scripts": {
+    "dev": "concurrently \"pnpm --filter apps/gui dev\" \"pnpm --filter packages/agent start:dev\"",
+    "typecheck": "tsc -p tsconfig.base.json --noEmit",
+    "build": "pnpm run typecheck && pnpm --filter apps/gui run build",
+    "build:cli": "pnpm --filter packages/agent run build:cli"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1",
+    "typescript": "^5.0.0",
+    "eslint": "^8.0.0",
+    "prettier": "^3.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0"
+  }
+}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "agent",
+  "version": "0.1.0",
+  "private": true,
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "start:dev": "ts-node src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "build:cli": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "toml": "^3.0.0",
+    "winston": "^3.9.0",
+    "systeminformation": "^5.20.0",
+    "dockerode": "^3.3.0",
+    "node-cron": "^3.0.0",
+    "open": "^9.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  }
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,1 @@
+console.log('agent');

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@agent/*": ["packages/agent/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- setup pnpm workspaces for `apps/gui` and `packages/agent`
- add TypeScript base config with strict options and path alias
- configure ESLint and Prettier
- bootstrap Electron React GUI and agent package
- document build and dev scripts in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f0a3fafd08325b07e3db2293694ee