### PR TITLE
Implement agent runtime

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -5,25 +5,26 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "start:dev": "ts-node src/index.ts",
+    "start:dev": "ts-node src/agent.ts",
     "build": "tsc -p tsconfig.json",
     "build:cli": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "axios": "^1.6.0",
-    "toml": "npm:@iarna/toml@^2.2.5",
-    "winston": "^3.9.0",
-    "systeminformation": "^5.20.0",
     "dockerode": "^3.3.0",
+    "form-data": "^4.0.0",
     "node-cron": "^3.0.0",
     "open": "^9.0.0",
+    "systeminformation": "^5.20.0",
     "tar": "^7.0.0",
-    "form-data": "^4.0.0"
+    "toml": "npm:@iarna/toml@^2.2.5",
+    "winston": "^3.9.0"
   },
   "devDependencies": {
-    "typescript": "^5.0.0",
-    "ts-node": "^10.0.0",
     "@types/dockerode": "^3.3.41",
-    "@types/form-data": "^2.5.2"
+    "@types/form-data": "^2.5.2",
+    "@types/node-cron": "^3.0.11",
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,0 +1,115 @@
+import path from 'path';
+import cron from 'node-cron';
+import winston from 'winston';
+import { AiChainAPI, getLogTail } from './api';
+import { detectHardware } from './hardware';
+import { executeJob } from './executeJob';
+import { loadConfig, saveConfig, getConfigDir, Config } from './config';
+
+export class ConfigError extends Error {}
+
+function createLogger(level: Config['logLevel']): winston.Logger {
+  const dir = getConfigDir();
+  return winston.createLogger({
+    level,
+    format: winston.format.combine(
+      winston.format.timestamp(),
+      winston.format.printf(({ timestamp, level, message }) =>
+        `${timestamp} [${level}] ${message}`
+      )
+    ),
+    transports: [
+      new winston.transports.Console(),
+      new winston.transports.File({ filename: path.join(dir, 'agent.log') }),
+    ],
+  });
+}
+
+export async function runAgent(): Promise<void> {
+  const config = loadConfig();
+  if (!config.apiKey) {
+    throw new ConfigError('API key required – handled by GUI');
+  }
+
+  const logger = createLogger(config.logLevel);
+  const api = new AiChainAPI(config.apiKey);
+
+  let nodeId = config.nodeId;
+  if (!nodeId) {
+    logger.info('Detecting hardware and registering node');
+    const hw = await detectHardware();
+    const res: any = await api.registerNode(hw as any);
+    nodeId = res.nodeId || res.id;
+    if (typeof nodeId === 'string') {
+      saveConfig({ nodeId });
+    } else {
+      throw new Error('Invalid registerNode response');
+    }
+  }
+
+  let status: 'idle' | 'busy' = 'idle';
+  let shuttingDown = false;
+
+  const sendHeartbeat = async (s: 'idle' | 'busy' | 'offline') => {
+    try {
+      await api.heartbeat(nodeId!, s);
+    } catch (err) {
+      logger.error(`Heartbeat failed: ${String(err)}`);
+    }
+  };
+
+  const hb = cron.schedule('*/1 * * * *', () => sendHeartbeat(status), {
+    scheduled: true,
+  });
+
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    hb.stop();
+    await sendHeartbeat('offline');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  const pollLoop = async () => {
+    while (!shuttingDown) {
+      if (status === 'idle') {
+        try {
+          const job: any = await api.pollJob(nodeId!);
+          if (job && Object.keys(job).length > 0) {
+            status = 'busy';
+            await sendHeartbeat(status);
+            const result = await executeJob(job, logger);
+            if (result === 'success') {
+              await api.reportComplete(job.id, {});
+            } else {
+              const tail = await getLogTail(
+                50,
+                path.join(getConfigDir(), 'agent.log')
+              );
+              await api.reportFail(job.id, tail);
+            }
+            status = 'idle';
+            await sendHeartbeat(status);
+          }
+        } catch (err) {
+          logger.error(`Polling failed: ${String(err)}`);
+        }
+      }
+      await new Promise((r) => setTimeout(r, 15000));
+    }
+  };
+
+  await sendHeartbeat(status);
+  await pollLoop();
+}
+
+if (require.main === module) {
+  runAgent().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -46,7 +46,7 @@ export class AiChainAPI {
     return this.requestWithBackoff(() => this.client.post('/api/v1/nodes', hw));
   }
 
-  heartbeat(nodeId: string, status: 'idle' | 'busy') {
+  heartbeat(nodeId: string, status: 'idle' | 'busy' | 'offline') {
     return this.requestWithBackoff(() =>
       this.client.post(`/api/v1/nodes/${encodeURIComponent(nodeId)}/heartbeat`, { status })
     );

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -65,6 +65,15 @@ function ensureAppDir(): string {
 }
 
 /**
+ * Retrieve the path to the application configuration directory.
+ *
+ * The directory is created if it does not yet exist.
+ */
+export function getConfigDir(): string {
+  return ensureAppDir();
+}
+
+/**
  * Load the application configuration from `config.toml`.
  *
  * @returns The parsed configuration object.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,3 +1,5 @@
 export { detectHardware, type HardwareInfo } from './hardware';
 export { AiChainAPI, getLogTail } from './api';
 export { executeJob, type JobManifest } from './executeJob';
+export { loadConfig, saveConfig, type Config, getConfigDir } from './config';
+export { runAgent, ConfigError } from './agent';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       dockerode:
         specifier: ^3.3.0
         version: 3.3.5
+      form-data:
+        specifier: ^4.0.0
+        version: 4.0.3
       node-cron:
         specifier: ^3.0.0
         version: 3.0.3
@@ -75,6 +78,9 @@ importers:
       systeminformation:
         specifier: ^5.20.0
         version: 5.27.6
+      tar:
+        specifier: ^7.0.0
+        version: 7.4.3
       toml:
         specifier: npm:@iarna/toml@^2.2.5
         version: '@iarna/toml@2.2.5'
@@ -82,6 +88,15 @@ importers:
         specifier: ^3.9.0
         version: 3.17.0
     devDependencies:
+      '@types/dockerode':
+        specifier: ^3.3.41
+        version: 3.3.41
+      '@types/form-data':
+        specifier: ^2.5.2
+        version: 2.5.2
+      '@types/node-cron':
+        specifier: ^3.0.11
+        version: 3.0.11
       ts-node:
         specifier: ^10.0.0
         version: 10.9.2(@types/node@24.0.6)(typescript@5.8.3)
@@ -314,6 +329,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -478,8 +497,18 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.41':
+    resolution: {integrity: sha512-5kOi6bcnEjqfJ68ZNV/bBvSMLNIucc0XbRmBO4hg5OoFCoP99eSRcbMysjkzV7ZxQEmmc/zMnv4A7odwuKFzDA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/form-data@2.5.2':
+    resolution: {integrity: sha512-tfmcyHn1Pp9YHAO5r40+UuZUPAZbUEgqTel3EuEKpmF9hPkXgR4l41853raliXnb4gwyPNoQOfvgGGlHN5WSog==}
+    deprecated: This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
@@ -495,6 +524,12 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node-cron@3.0.11':
+    resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
+
+  '@types/node@18.19.113':
+    resolution: {integrity: sha512-TmSTE9vyebJ9vSEiU+P+0Sp4F5tMgjiEOZaQUW6wA3ODvi6uBgkHQ+EsIu0pbiKvf9QHEvyRCiaz03rV0b+IaA==}
 
   '@types/node@20.19.1':
     resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
@@ -521,6 +556,9 @@ packages:
 
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -792,6 +830,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
@@ -1601,11 +1643,20 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2009,6 +2060,10 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
+
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
@@ -2086,6 +2141,9 @@ packages:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2194,6 +2252,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -2409,6 +2471,10 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
@@ -2533,7 +2599,22 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 20.19.1
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.41':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 20.19.1
+      '@types/ssh2': 1.15.5
+
   '@types/estree@1.0.8': {}
+
+  '@types/form-data@2.5.2':
+    dependencies:
+      form-data: 4.0.3
 
   '@types/fs-extra@9.0.13':
     dependencies:
@@ -2548,6 +2629,12 @@ snapshots:
       '@types/node': 20.19.1
 
   '@types/ms@2.1.0': {}
+
+  '@types/node-cron@3.0.11': {}
+
+  '@types/node@18.19.113':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@20.19.1':
     dependencies:
@@ -2579,6 +2666,10 @@ snapshots:
       '@types/node': 20.19.1
 
   '@types/semver@7.7.0': {}
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.113
 
   '@types/triple-beam@1.3.5': {}
 
@@ -2936,6 +3027,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chromium-pickle-js@0.2.0: {}
 
@@ -3865,9 +3958,15 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   ms@2.1.3: {}
 
@@ -4276,6 +4375,15 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
+
   temp-file@3.4.0:
     dependencies:
       async-exit-hook: 2.0.1
@@ -4341,6 +4449,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   typescript@5.8.3: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -4425,6 +4535,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- extend API heartbeat to accept `offline`
- expose agent config directory helper
- add agent runtime script with heartbeat and job polling
- export new runtime functions and config helpers
- update development script

## Testing
- `pnpm --filter agent run build:cli`

------
https://chatgpt.com/codex/tasks/task_e_686067249a448325add54c44104a72d1